### PR TITLE
Prevents integer conversion in URL

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -76,7 +76,7 @@ get_ft <- function(endpoint){
   # Use an lapply loop to fetch data
   ft_data_list <- pbapply::pblapply(seqnr, function(i){
 
-    url <- paste0(base_url, "&$skip=", i)
+    url <- paste0(base_url, "&$skip=", as.integer(i))
 
     ft_data <- httr::GET(url)
     ft_data <- httr::content(ft_data)


### PR DESCRIPTION
#1 This issue was caused by integers >100000 being converted to scientific notation, causing the API request to fail. 

This example shows how the error occured, and how it is fixed.
``` r
  href <- "Stemme"
  
  # Create a baseurl for that endpoint
  base_url <- paste0("http://oda.ft.dk/api/", href, "?$inlinecount=allpages")
  paste0(base_url, "&$skip=", 100000)
#> [1] "http://oda.ft.dk/api/Stemme?$inlinecount=allpages&$skip=1e+05"
  paste0(base_url, "&$skip=", as.integer(100000))
#> [1] "http://oda.ft.dk/api/Stemme?$inlinecount=allpages&$skip=100000"
```


